### PR TITLE
Do not check for 'adv_spawning' global

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -10,10 +10,6 @@
 
 local version = "0.0.13"
 
-if adv_spawning ~= nil then
-	core.log("error", "MOD: adv_spawning requires adv_spawning variable to be available")
-end
-
 --------------------------------------------------------------------------------
 -- @type adv_spawning base element for usage of adv_spawning
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
Removes check for *adv_spawning* global variable.

Please correct me if I am wrong, but check is done before variable is created. And, seems redundant to do check within mod where variable is created anyway.